### PR TITLE
Add support for YAML and JSON output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.5.2 - 2021-11-15
+- Add support for YAML and JSON output formats.
 
 ## 0.5.1 - 2021-09-14
 - Add branch name option to git checkout operation.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Options:
   --export-criteria TEXT          Specify saved criteria to export to a file.
   --export-file PATH              File to write exported rules to.
   --import-criteria PATH          Import previously exported criteria.
+  --output-format [plaintext|yaml|json]
+                                  Format of the command output [default=plaintext].
   --verbose                       Enable debug logging.
   --help                          Show this message and exit.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-co-evg-base"
-version = "0.5.1"
+version = "0.5.2"
 description = "Find a good commit to base your work on"
 authors = ["David Bradford <david.bradford@mongodb.com>"]
 readme = "README.md"

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -554,14 +554,14 @@ def main(
 
         if revision:
             revision_dict = {}
-            revision_dict["mongo"] = revision.revision
+            revision_dict["stable_revision"] = revision.revision
             for module_name, module_revision in revision.module_revisions.items():
                 revision_dict[module_name] = module_revision
 
             if output_format == "yaml":
-                click.echo(click.style(yaml.dump(revision_dict, sort_keys=False), fg="green"))
+                print(yaml.dump(revision_dict, sort_keys=False))
             elif output_format == "json":
-                click.echo(click.style(json.dumps(revision_dict), fg="green"))
+                print(json.dumps(revision_dict))
             else:  # "plaintext"
                 click.echo(click.style(f"Found revision: {revision.revision}", fg="green"))
                 for module_name, module_revision in revision.module_revisions.items():


### PR DESCRIPTION
Introducing a new command option `--output-format`, using which users can select desired command output format. Adding support for YAML and JSON formats on top of the existing plaintext format (default).

Sample runs with different output format selections:
```
09:21:32 (git-co-evg-base-UmS_VU3t-py3.9) lchen@192-168-1-100 mongo-wtdrop ±||→ git-co-evg-base
Searching mongodb-mongo-master revisions  [------------------------------------]    0%
Found revision: b4517954a706b9f49b17d423f179113aa8632565
	enterprise: 1f9179cceb1eeb0d8ee1a5c7913d87ac76c5fb85
	wtdevelop: 6eeb4f7e61e7b34b7667f9fdd20e6ed5c55bd498

09:22:04 (git-co-evg-base-UmS_VU3t-py3.9) lchen@192-168-1-100 mongo-wtdrop ±||→ git-co-evg-base --output-format json
Searching mongodb-mongo-master revisions  [------------------------------------]    0%
{"mongo": "b4517954a706b9f49b17d423f179113aa8632565", "enterprise": "1f9179cceb1eeb0d8ee1a5c7913d87ac76c5fb85", "wtdevelop": "6eeb4f7e61e7b34b7667f9fdd20e6ed5c55bd498"}

09:22:51 (git-co-evg-base-UmS_VU3t-py3.9) lchen@192-168-1-100 mongo-wtdrop ±||→ git-co-evg-base --output-format yaml
Searching mongodb-mongo-master revisions  [------------------------------------]    0%
mongo: b4517954a706b9f49b17d423f179113aa8632565
enterprise: 1f9179cceb1eeb0d8ee1a5c7913d87ac76c5fb85
wtdevelop: 6eeb4f7e61e7b34b7667f9fdd20e6ed5c55bd498
```